### PR TITLE
Replace USBSerial by Serial to avoid building issues:  error: 'USBSerial' was not declared in this scope

### DIFF
--- a/src/M5CoreS3.cpp
+++ b/src/M5CoreS3.cpp
@@ -11,14 +11,19 @@ M5CoreS3::~M5CoreS3() {
 }
 
 void M5CoreS3::begin(bool LCDEnable, bool USBSerialEnable, bool I2CEnable) {
-    if (USBSerialEnable) {
-        USBSerial.begin(115200);
-        USBSerial.flush();
+    /*
+    if (SerialEnable) {
+        Serial.begin(115200);
+        Serial.flush();
         delay(1500);
-        USBSerial.println("M5CoreS3 initializing...OK");
+        Serial.println("M5CoreS3 initializing...OK");
     }
-
-    USBSerial.printf("APX initial:%d\n", Axp.begin(&Wire1));
+    */
+    Serial.begin(115200);
+    Serial.flush();
+    delay(1500);
+    Serial.println("M5CoreS3 initializing...OK");
+    Serial.printf("APX initial:%d\n", Axp.begin(&Wire1));
 
     if (LCDEnable) {
         Axp.coreS3_init();

--- a/src/utility/I2C_IMU.cpp
+++ b/src/utility/I2C_IMU.cpp
@@ -7,7 +7,7 @@ bool bmm150_init_flag = false;  // FIXME: dirty code
 
 I2C_IMU::I2C_IMU() {
     Wire1.begin(12, 11, 100000UL);
-    USBSerial.begin(115200);
+    Serial.begin(115200);
 }
 
 I2C_IMU::~I2C_IMU() {
@@ -93,7 +93,7 @@ void I2C_IMU::Init() {
     /* Map data ready interrupt to interrupt pin. */
     ret = bmi2_map_data_int(BMI2_DRDY_INT, BMI2_INT1, &aux_bmi2_dev);
 
-    USBSerial.printf("Valid BMM150 (Aux) sensor - Chip ID : 0x%x\r\n",
+    Serial.printf("Valid BMM150 (Aux) sensor - Chip ID : 0x%x\r\n",
                      aux_bmm150_dev.chip_id);
 
     if (aux_bmm150_dev.chip_id == BMM150_CHIP_ID) {


### PR DESCRIPTION
Replace USBSerial by Serial to avoid building issues: 
error: 'USBSerial' was not declared in this scope

Fixes #21.

Building is OK with this dirty fix.