### PR TITLE
"USB Mode" & "USB CDC On Boot" menu options

### DIFF
--- a/src/M5CoreS3.h
+++ b/src/M5CoreS3.h
@@ -1,6 +1,14 @@
 #ifndef _M5CORES3_H_
 #define _M5CORES3_H_
 
+#if ARDUINO_USB_CDC_ON_BOOT
+  #define USBSerial Serial
+#else
+  #include <HWCDC.h>
+  // the warning produced by using the 'inline' keyword is a necessary evil as (HWCDC)USBSerial is declared extern and can't be casted as static
+  inline HWCDC USBSerial;
+#endif
+
 #include <Arduino.h>
 #include <Wire.h>
 #include "FS.h"

--- a/src/utility/I2C_IMU.cpp
+++ b/src/utility/I2C_IMU.cpp
@@ -7,7 +7,7 @@ bool bmm150_init_flag = false;  // FIXME: dirty code
 
 I2C_IMU::I2C_IMU() {
     Wire1.begin(12, 11, 100000UL);
-    USBSerial.begin(115200);
+    //USBSerial.begin(115200); // wut?
 }
 
 I2C_IMU::~I2C_IMU() {
@@ -93,7 +93,7 @@ void I2C_IMU::Init() {
     /* Map data ready interrupt to interrupt pin. */
     ret = bmi2_map_data_int(BMI2_DRDY_INT, BMI2_INT1, &aux_bmi2_dev);
 
-    USBSerial.printf("Valid BMM150 (Aux) sensor - Chip ID : 0x%x\r\n",
+    printf("Valid BMM150 (Aux) sensor - Chip ID : 0x%x\r\n",
                      aux_bmm150_dev.chip_id);
 
     if (aux_bmm150_dev.chip_id == BMM150_CHIP_ID) {


### PR DESCRIPTION
- add a safeguard to make sure that USBSerial always prints to the connected Serial interface, whatever `USB Mode` or `USB CDC On Boot` menu option is selected (see https://github.com/espressif/arduino-esp32/pull/8276).
- remove redundant call to USBSerial.begin() in I2C_IMU.cpp and use standard output to print IMU ChipID


