### PR TITLE
GC0308: add explicit constructor to enable custom camera configs

### DIFF
--- a/src/utility/GC0308.cpp
+++ b/src/utility/GC0308.cpp
@@ -32,10 +32,19 @@ static camera_config_t camera_config = {
     .sccb_i2c_port = -1,
 };
 
-bool GC0308::begin()
+GC0308::GC0308() {
+    fb = nullptr;
+    sensor = nullptr;
+    config = &camera_config;
+}
+
+bool GC0308::begin(camera_config_t* _config)
 {
     M5.In_I2C.release();
-    esp_err_t err = esp_camera_init(&camera_config);
+    if (_config) {
+        config = _config;
+    }
+    esp_err_t err = esp_camera_init(config);
     if (err != ESP_OK) {
         return false;
     }

--- a/src/utility/GC0308.h
+++ b/src/utility/GC0308.h
@@ -10,7 +10,9 @@ public:
     camera_fb_t* fb;
     sensor_t* sensor;
     camera_config_t* config;
-    bool begin();
+
+    GC0308();
+    bool begin(camera_config_t* _config = nullptr);
     bool get();
     bool free();
 };


### PR DESCRIPTION
the way this was coded made the camera_config_t* config; member variable useless, as it is never set or used.

with this change:

- the constructor can optionally accept a pointer to a custom camera_config_t struct
- when using the default camera_config, it can be accessed and changed via the config member variable or by passing a custom config via begin
- the used config struct can always be accessed via the config member.

Here is a demo for the CoreS3 which reads and decodes a QRcode via the builtin camera, and connects to WiFi if the qrcode was a Wifi URI:

 https://github.com/mhaberler/cores3-read-qrcode.git
 
 this uses the patch attached to customize the camera config (resolution, grayscale):